### PR TITLE
Fix instructions for conda install. on non-debian based systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ ASAP to get this space**.
         * Mac: `wget https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh` or `curl -LOk https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh`
         * Or just simply download from [the site](https://conda.io/miniconda.html)
 1. Install miniconda2 *with default settings*
-    1. `sh Miniconda2-latest-Linux-x86_64.sh`
+    1. `bash Miniconda2-latest-Linux-x86_64.sh`
     1. Follow the prompt - **type `yes` and hit `enter` to accept all default
     settings when asked**
 1. Close Terminal and reopen


### PR DESCRIPTION
Attempting to install miniconda2 with `sh` on a Debian derivative indicates problems with reading the install script. This is likely because `sh` resolves to `dash` on these distros, instead of `bash` as on DICE. This can be seen by running `readlink /usr/bin/sh` on e.g. Ubuntu. It's thus preferable to instruct people to use `bash` for the install script.

