### PR TITLE
Fixed typo in example submit command.

### DIFF
--- a/03_Assignment_1.ipynb
+++ b/03_Assignment_1.ipynb
@@ -44,7 +44,7 @@
     "\n",
     "Place your notebook in a directory called `iamlans` and submit this directory using the submit command on a DICE machine:\n",
     "\n",
-    "`submit iaml 1 iamlans`\n",
+    "`submit iaml cw1 iamlans`\n",
     "\n",
     "Please note the importance of the number. **This should changed with each assignment!** Also note that submitting again will *overwrite* your previous submission. You can check the status of your submissions with the `show_submissions` command.\n",
     "\n",


### PR DESCRIPTION
The example submit command was
`submit iaml 1 iamlans`
However, when you try to run this command, it fails with

> The exercise name should be one of:
cw4 cw3 cw2 cw1 
 for course iaml.

I have changed the example command to 
`submit iaml cw1 iamlans`
which appears to have worked for me.